### PR TITLE
feat: add ARM64 macOS build support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,17 +175,23 @@ jobs:
     strategy:
       matrix:
         include:
+          # Linux builds
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
             binary-suffix: ""
+          - os: ubuntu-latest
+            target: aarch64-unknown-linux-gnu
+            binary-suffix: ""
+          # Windows builds
           - os: windows-latest
             target: x86_64-pc-windows-msvc
             binary-suffix: ".exe"
+          # macOS builds
           - os: macos-latest
-            target: x86_64-apple-darwin
+            target: x86_64-apple-darwin      # Intel Mac
             binary-suffix: ""
-          - os: ubuntu-latest
-            target: aarch64-unknown-linux-gnu
+          - os: macos-latest
+            target: aarch64-apple-darwin     # Apple Silicon (M1/M2)
             binary-suffix: ""
     
     steps:


### PR DESCRIPTION
## 📋 Description
Adds native ARM64 (Apple Silicon) macOS build support to the CI/CD pipeline.

## 🔧 Changes Made
- ✅ Added `aarch64-apple-darwin` target for M1/M2 Macs
- ✅ Organized build matrix with clear comments
- ✅ Maintains existing Intel macOS support

## 🚀 Build Targets Now Include
**Linux:**
- `x86_64-unknown-linux-gnu` (Intel/AMD)
- `aarch64-unknown-linux-gnu` (ARM64)

**Windows:**
- `x86_64-pc-windows-msvc` (Intel/AMD)

**macOS:**
- `x86_64-apple-darwin` (Intel Mac)
- `aarch64-apple-darwin` (Apple Silicon M1/M2) ← **NEW**

## 🎯 Benefits
- Native performance on Apple Silicon Macs
- No Rosetta translation layer needed
- Complete platform coverage for modern hardware
- Future-proof for Apple's ARM transition

## 🧪 Testing
This PR will test the new ARM64 macOS build in CI to ensure it compiles and works correctly.

Ready to provide native Apple Silicon binaries! 🍎⚡