### PR TITLE
Fix: Add required permissions for auto-merge workflow

### DIFF
--- a/.github/workflows/auto-merge-solo.yml
+++ b/.github/workflows/auto-merge-solo.yml
@@ -6,6 +6,11 @@ on:
     branches: [feature/*, hotfix/*, bugfix/*]
     types: [completed]
 
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
 jobs:
   auto-merge-solo:
     name: Auto-merge for solo development


### PR DESCRIPTION
🔧 **Fix: Auto-merge Permissions**

This PR adds the required permissions to enable full auto-merge automation.

## Problem Solved:
- ❌ Auto-merge workflow failed with "Resource not accessible by integration"
- ❌ Missing GitHub Actions permissions for PR operations

## Solution Applied:
✅ Added `permissions` block with required scopes:
- `contents: write` - For merging pull requests
- `pull-requests: write` - For merge operations  
- `issues: write` - For adding success/failure comments

## Expected Result:
🎯 **Complete automation!** Auto-merge should now work end-to-end:
1. CI completes successfully ✅
2. Auto-merge workflow triggers ✅  
3. PR gets merged automatically ✅
4. Success comment added ✅

This is the final piece to complete our auto-merge system! 🚀
