### PR TITLE
fix: ensure CI runs on main after auto-merge

### DIFF
--- a/.github/workflows/auto-merge-solo.yml
+++ b/.github/workflows/auto-merge-solo.yml
@@ -93,6 +93,31 @@ jobs:
             throw error;
           }
 
+    - name: Trigger CI on main branch
+      if: steps.get-pr.outputs.pr_number != ''
+      uses: actions/github-script@v7
+      with:
+        script: |
+          console.log('🔄 Triggering CI workflow on main branch...');
+          
+          try {
+            await github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'ci.yml',
+              ref: 'main',
+              inputs: {
+                trigger_reason: 'Post auto-merge validation',
+                merged_pr: '${{ steps.get-pr.outputs.pr_number }}'
+              }
+            });
+            
+            console.log('✅ Main branch CI workflow triggered');
+          } catch (error) {
+            console.log('⚠️ Failed to trigger main branch CI:', error.message);
+            // Don't fail the entire workflow if CI trigger fails
+          }
+
     - name: Log merge status
       if: always()
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,11 +1,26 @@
 name: CI/CD Pipeline
 
+# CI triggers:
+# - PRs: Validation and early feedback before merge
+# - Main/Develop: Final verification, release builds, and deployment prep
+# - Manual: Post auto-merge validation and release preparation
 on:
   push:
     branches: [ main, develop ]
   pull_request:
     branches: [ main ]
     types: [opened, synchronize, reopened, ready_for_review]
+  workflow_dispatch:
+    inputs:
+      trigger_reason:
+        description: 'Reason for manual trigger'
+        required: false
+        default: 'Manual trigger'
+        type: string
+      merged_pr:
+        description: 'PR number that was auto-merged'
+        required: false
+        type: string
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
## Problem

Auto-merged PRs weren't triggering CI on the main branch due to GitHub's design that prevents workflow-triggered merges from creating push events (to avoid infinite loops).

## Solution

- Add `workflow_dispatch` trigger to CI workflow
- Auto-merge workflow now triggers CI on main after successful merge
- Ensures main branch validation and release artifact builds

## Testing

This PR will test the fix:
1. CI runs on this PR branch ✅
2. Auto-merge merges to main
3. Auto-merge triggers CI on main branch (new behavior)
4. Main branch gets validated + release artifacts built

Resolves the missing main branch CI issue.