### PR TITLE
fix: add update-* branch pattern to auto-merge workflow

### DIFF
--- a/.github/workflows/auto-merge-solo.yml
+++ b/.github/workflows/auto-merge-solo.yml
@@ -3,7 +3,7 @@ name: Auto-merge Solo Development
 on:
   workflow_run:
     workflows: ["CI/CD Pipeline"]
-    branches: [feature/*, hotfix/*, bugfix/*]
+    branches: [feature/*, hotfix/*, bugfix/*, update-*]
     types: [completed]
 
 permissions:


### PR DESCRIPTION
## Summary

Improves the auto-merge workflow to include  branch patterns, enabling automatic merging of documentation updates and similar changes.

## Changes

- ✅ Add  to auto-merge workflow branch patterns
- ✅ Maintain existing , ,  patterns
- ✅ Enable automatic merging for documentation and configuration updates

## Testing

This PR uses the  branch pattern and should trigger the auto-merge workflow once CI passes, testing the fix.

## Background

PR #16 (README Phase 4 update) used branch  which didn't match the previous patterns, requiring manual merge. This fix ensures future documentation updates can auto-merge.

## Verification

- Branch name:  ✅ matches new pattern
- All existing patterns preserved ✅
- Auto-merge workflow permissions already fixed in PR #15 ✅