### PR TITLE
chore: exclude tests/test-data from GitHub language stats

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -31,3 +31,6 @@ LICENSE* text eol=lf
 *.db binary
 *.sqlite binary
 *.sqlite3 binary
+
+# Exclude tests/test-data from GitHub language stats using linguist-vendored
+tests/test-data/** linguist-vendored


### PR DESCRIPTION
This PR adds a .gitattributes rule to mark tests/test-data as linguist-vendored, so that GitHub will ignore it for language statistics and code search, but the files remain in the repo for testing purposes.